### PR TITLE
feat: add basic binary operators

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -8,6 +8,12 @@ typedef enum {
   OP_CONSTANT,
   OP_NEGATE,
   OP_RETURN,
+
+  // binary operators
+  OP_ADD,
+  OP_SUBTRACT,
+  OP_MULTIPLY,
+  OP_DIVIDE,
 } OpCode;
 
 typedef struct {

--- a/debug.c
+++ b/debug.c
@@ -33,12 +33,20 @@ int disassembleInstruction(Chunk* chunk, int offset) {
 
   uint8_t instruction = chunk->code[offset];
   switch(instruction) {
+    case OP_ADD:
+      return simpleInstruction("OP_ADD", offset);
     case OP_CONSTANT:
       return constantInstruction("OP_CONSTANT", chunk, offset);
+    case OP_DIVIDE:
+      return simpleInstruction("OP_DIVIDE", offset);
+    case OP_MULTIPLY:
+      return simpleInstruction("OP_MULTIPLY", offset);
     case OP_NEGATE:
       return simpleInstruction("OP_NEGATE", offset);
     case OP_RETURN:
       return simpleInstruction("OP_RETURN", offset);
+    case OP_SUBTRACT:
+      return simpleInstruction("OP_SUBTRACT", offset);
     default:
       printf("Unknown opcode %d\n", instruction);
       return offset + 1;

--- a/main.c
+++ b/main.c
@@ -12,9 +12,22 @@ int main(int argc, const char* argv[]) {
   int constant = addConstant(&chunk, 1.2);
   writeChunk(&chunk, OP_CONSTANT, 123);
   writeChunk(&chunk, constant, 123);
-  writeChunk(&chunk, OP_NEGATE, 123);
 
-  writeChunk(&chunk, OP_RETURN, 124);
+  constant = addConstant(&chunk, 3.4);
+  writeChunk(&chunk, OP_CONSTANT, 124);
+  writeChunk(&chunk, constant, 124);
+
+  writeChunk(&chunk, OP_ADD, 124);
+
+  constant = addConstant(&chunk, 5.6);
+  writeChunk(&chunk, OP_CONSTANT, 124);
+  writeChunk(&chunk, constant, 124);
+
+  writeChunk(&chunk, OP_DIVIDE, 124);
+
+  writeChunk(&chunk, OP_NEGATE, 124);
+
+  writeChunk(&chunk, OP_RETURN, 126);
 
   // for debugging purposes
   // disassembleChunk(&chunk, "test chunk");

--- a/vm.c
+++ b/vm.c
@@ -43,6 +43,13 @@ InterpretResult interpret(Chunk* chunk) {
 static InterpretResult run() {
 #define READ_BYTE() (*vm.ip++)
 #define READ_CONSTANT() (vm.chunk->constants.values[READ_BYTE()])
+#define BINARY_OP(op) \
+    do { \
+      double b = pop(); \
+      double a = pop(); \
+      push(a op b); \
+    } while (false)
+
   for (;;) {
 #ifdef DEBUG_TRACE_EXECUTION
     printf("          ");
@@ -56,9 +63,21 @@ static InterpretResult run() {
 #endif
     uint8_t instruction;
     switch (instruction = READ_BYTE()) {
+      case OP_ADD: {
+        BINARY_OP(+);
+        break;
+      }
       case OP_CONSTANT: {
         Value constant = READ_CONSTANT();
         push(constant);
+        break;
+      }
+      case OP_DIVIDE: {
+        BINARY_OP(/);
+        break;
+      }
+      case OP_MULTIPLY: {
+        BINARY_OP(*);
         break;
       }
       case OP_NEGATE: {
@@ -70,8 +89,14 @@ static InterpretResult run() {
         printf("\n");
         return INTERPRET_OK;
       }
+      case OP_SUBTRACT: {
+        BINARY_OP(-);
+        break;
+      }
     }
   }
-#undef READ_CONSTANT
+
 #undef READ_BYTE
+#undef READ_CONSTANT
+#undef BINARY_OP
 }


### PR DESCRIPTION
Add support for `add`, `subtract`, `multiply`, and `divide` operators.

Some notes on the macro:

The `do...while` loop allows the entire block to be _treated as a block_, no matter how it is used.

Imagine
```c
#define WAKE_UP() makeCoffee(); drinkCoffee();
```
Then a use like
```c
if (morning) WAKE_UP();
```
would be expanded as
```c
if (morning) makeCoffee(); drinkCoffee();`
```
and one would drink the coffee all the time, sometimes without making it!

Consider, then, putting it within a block
```c
#define WAKE_UP() { makeCoffee(); drinkCoffee(); }
```
and then a use like
```c
if (morning)
  WAKE_UP();
else
  sleepIn();
```
which gets expanded as
```c
if (morning)
  { makeCoffee(); drinkCoffee(); };
else
  sleepIn();
```
and the compiler raises an error for the semicolon before the `else`.

Using the `do...while` loop allows for these uses without problem, even if it looks a little funny within the macro. And the C compiler will most likely remove it as unecessary in the middle end.