### PR TITLE
feat: compiler scaffolding

### DIFF
--- a/common.h
+++ b/common.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define DEBUG_PRINT_CODE
 #define DEBUG_TRACE_EXECUTION
 
 #endif

--- a/compiler.c
+++ b/compiler.c
@@ -6,6 +6,10 @@
 #include "scanner.h"
 #include "value.h"
 
+#ifdef DEBUG_PRINT_CODE
+#include "debug.h"
+#endif
+
 typedef struct {
   Token current;
   Token previous;
@@ -25,7 +29,15 @@ typedef enum {
   PREC_UNARY,       // ! -
   PREC_CALL,        // . ()
   PREC_PRIMARY
-} Precendence;
+} Precedence;
+
+typedef void (*ParseFn)();
+
+typedef struct {
+  ParseFn prefix;
+  ParseFn infix;
+  Precedence precedence;
+} ParseRule;
 
 Parser parser;
 Chunk* compilingChunk;
@@ -37,12 +49,14 @@ static void emitByte(uint8_t byte);
 static void emitBytes(uint8_t byte1, uint8_t byte2);
 static void emitConstant(Value value);
 
+static void binary();
 static void expression();
 static void grouping();
 static void number();
 static void unary();
 
-static void parsePrecendence(Precendence precedence);
+static void parsePrecedence(Precedence precedence);
+static ParseRule* getRule(TokenType type);
 
 static void errorAtCurrent(const char* message);
 static void error(const char* message);
@@ -100,7 +114,7 @@ static Chunk* currentChunk() {
 }
 
 static void expression() {
-  parsePrecendence(PREC_ASSIGNMENT);
+  parsePrecedence(PREC_ASSIGNMENT);
 }
 
 static void errorAtCurrent(const char* message) {
@@ -133,6 +147,25 @@ static void emitReturn() {
 
 static void endCompiler() {
   emitReturn();
+#ifdef DEBUG_PRINT_CODE
+  if (!parser.hadError) {
+    disassembleChunk(currentChunk(), "code");
+  }
+#endif
+}
+
+static void binary() {
+  TokenType operatorType = parser.previous.type;
+  ParseRule* rule = getRule(operatorType);
+  parsePrecedence((Precedence)(rule->precedence + 1));
+
+  switch (operatorType) {
+    case TOKEN_PLUS: emitByte(OP_ADD); break;
+    case TOKEN_MINUS: emitByte(OP_SUBTRACT); break;
+    case TOKEN_STAR: emitByte(OP_MULTIPLY); break;
+    case TOKEN_SLASH: emitByte(OP_DIVIDE); break;
+    default: return;  // unreachable
+  }
 }
 
 static void number() {
@@ -149,7 +182,7 @@ static void unary() {
   TokenType operatorType = parser.previous.type;
 
   // compile the operand
-  parsePrecendence(PREC_UNARY);
+  parsePrecedence(PREC_UNARY);
 
   // emit the operator instruction
   switch (operatorType) {
@@ -158,8 +191,21 @@ static void unary() {
   }
 }
 
-static void parsePrecendence(Precendence precedence) {
-  // what goes here?
+static void parsePrecedence(Precedence precedence) {
+  advance();
+  ParseFn prefixRule = getRule(parser.previous.type)->prefix;
+  if (prefixRule == NULL) {
+    error("Expect expression");
+    return;
+  }
+
+  prefixRule();
+
+  while (precedence <= getRule(parser.current.type)->precedence) {
+    advance();
+    ParseFn infixRule = getRule(parser.previous.type)->infix;
+    infixRule();
+  }
 }
 
 static void emitConstant(Value value) {
@@ -174,4 +220,51 @@ static uint8_t makeConstant(Value value) {
   }
 
   return (uint8_t)constant;
+}
+
+ParseRule rules[] = {
+  [TOKEN_LEFT_PAREN]    = {grouping, NULL,   PREC_NONE},
+  [TOKEN_RIGHT_PAREN]   = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_LEFT_BRACE]    = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_RIGHT_BRACE]   = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_COMMA]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_DOT]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_MINUS]         = {unary,    binary, PREC_TERM},
+  [TOKEN_PLUS]          = {NULL,     binary, PREC_TERM},
+  [TOKEN_SEMICOLON]     = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_SLASH]         = {NULL,     binary, PREC_FACTOR},
+  [TOKEN_STAR]          = {NULL,     binary, PREC_FACTOR},
+  [TOKEN_BANG]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_BANG_EQUAL]    = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_EQUAL]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_EQUAL_EQUAL]   = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_GREATER]       = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_GREATER_EQUAL] = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_LESS]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_LESS_EQUAL]    = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_IDENTIFIER]    = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_STRING]        = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_NUMBER]        = {number,   NULL,   PREC_NONE},
+  [TOKEN_AND]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_CLASS]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_ELSE]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_FALSE]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_FOR]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_FUN]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_IF]            = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_NIL]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_OR]            = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_PRINT]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_RETURN]        = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_SUPER]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_THIS]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_TRUE]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_VAR]           = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_WHILE]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_ERROR]         = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_EOF]           = {NULL,     NULL,   PREC_NONE},
+};
+
+ParseRule* getRule(TokenType type) {
+  return &rules[type];
 }

--- a/compiler.c
+++ b/compiler.c
@@ -1,23 +1,177 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "common.h"
 #include "compiler.h"
 #include "scanner.h"
+#include "value.h"
 
-void compile(const char* source) {
+typedef struct {
+  Token current;
+  Token previous;
+  bool hadError;
+  bool panicMode;
+} Parser;
+
+typedef enum {
+  PREC_NONE,
+  PREC_ASSIGNMENT,  //  =
+  PREC_OR,          // or
+  PREC_AND,         // and
+  PREC_EQUALITY,    // == !=
+  PREC_COMPARISON,  // < > <= >=
+  PREC_TERM,        // + -
+  PREC_FACTOR,      // * /
+  PREC_UNARY,       // ! -
+  PREC_CALL,        // . ()
+  PREC_PRIMARY
+} Precendence;
+
+Parser parser;
+Chunk* compilingChunk;
+
+static void advance();
+static void consume(TokenType type, const char* message);
+
+static void emitByte(uint8_t byte);
+static void emitBytes(uint8_t byte1, uint8_t byte2);
+static void emitConstant(Value value);
+
+static void expression();
+static void grouping();
+static void number();
+static void unary();
+
+static void parsePrecendence(Precendence precedence);
+
+static void errorAtCurrent(const char* message);
+static void error(const char* message);
+static void errorAt(Token* token, const char* message);
+
+static Chunk* currentChunk();
+static void endCompiler();
+static uint8_t makeConstant(Value value);
+
+bool compile(const char* source, Chunk* chunk) {
   initScanner(source);
+  compilingChunk = chunk;
 
-  int line = -1;
+  parser.hadError = false;
+  parser.panicMode = false;
+
+  advance();
+  expression();
+  consume(TOKEN_EOF, "Expect end of expression.");
+  endCompiler();
+  return !parser.hadError;
+}
+
+static void advance() {
+  parser.previous = parser.current;
+
   for (;;) {
-    Token token = scanToken();
-    if (token.line != line) {
-      printf("%4d ", token.line);
-      line = token.line;
-    } else {
-      printf("   | ");
-    }
-    printf("%2d '%.*s'\n", token.type, token.length, token.start);
+    parser.current = scanToken();
+    if (parser.current.type != TOKEN_ERROR) break;
 
-    if (token.type == TOKEN_EOF) break;
+    errorAtCurrent(parser.current.start);
   }
+}
+
+static void consume(TokenType type, const char* message) {
+  if (parser.current.type == type) {
+    advance();
+    return;
+  }
+
+  errorAtCurrent(message);
+}
+
+static void emitByte(uint8_t byte) {
+  writeChunk(currentChunk(), byte, parser.previous.line);
+}
+
+static void emitBytes(uint8_t byte1, uint8_t byte2) {
+  emitByte(byte1);
+  emitByte(byte2);
+}
+
+static Chunk* currentChunk() {
+  return compilingChunk;
+}
+
+static void expression() {
+  parsePrecendence(PREC_ASSIGNMENT);
+}
+
+static void errorAtCurrent(const char* message) {
+  errorAt(&parser.current, message);
+}
+
+static void error(const char* message) {
+  errorAt(&parser.previous, message);
+}
+
+static void errorAt(Token* token, const char* message) {
+  if (parser.panicMode) return;
+  parser.panicMode = true;
+
+  fprintf(stderr, "[line %d] Error", token->line);
+
+  if (token->type == TOKEN_EOF) {
+    fprintf(stderr, " at end");
+  } else if (token->type != TOKEN_ERROR) {
+    fprintf(stderr, " at '%.*s'", token->length, token->start);
+  }
+
+  fprintf(stderr, ": %s\n", message);
+  parser.hadError = true;
+}
+
+static void emitReturn() {
+  emitByte(OP_RETURN);
+}
+
+static void endCompiler() {
+  emitReturn();
+}
+
+static void number() {
+  double value = strtod(parser.previous.start, NULL);
+  emitConstant(value);
+}
+
+static void grouping() {
+  expression();
+  consume(TOKEN_RIGHT_PAREN, "Expect ')' after expression");
+}
+
+static void unary() {
+  TokenType operatorType = parser.previous.type;
+
+  // compile the operand
+  parsePrecendence(PREC_UNARY);
+
+  // emit the operator instruction
+  switch (operatorType) {
+    case TOKEN_MINUS: emitByte(OP_NEGATE); break;
+    default: return;  // unreachable
+  }
+}
+
+static void parsePrecendence(Precendence precedence) {
+  // what goes here?
+}
+
+static void emitConstant(Value value) {
+  emitBytes(OP_CONSTANT, makeConstant(value));
+}
+
+static uint8_t makeConstant(Value value) {
+  int constant = addConstant(currentChunk(), value);
+  if (constant > UINT8_MAX) {
+    error("Too many constants in one chunk");
+    return 0;
+  }
+
+  return (uint8_t)constant;
 }

--- a/compiler.h
+++ b/compiler.h
@@ -1,6 +1,8 @@
 #ifndef clox_compiler_h
 #define clox_compiler_h
 
-void compile(const char* source);
+#include "vm.h"
+
+bool compile(const char* source, Chunk* chunk);
 
 #endif

--- a/vm.c
+++ b/vm.c
@@ -36,8 +36,21 @@ Value pop() {
 }
 
 InterpretResult interpret(const char* source) {
-  compile(source);
-  return INTERPRET_OK;
+  Chunk chunk;
+  initChunk(&chunk);
+
+  if (!compile(source, &chunk)) {
+    freeChunk(&chunk);
+    return INTERPRET_COMPILE_ERROR;
+  }
+
+  vm.chunk = &chunk;
+  vm.ip = vm.chunk->code;
+
+  InterpretResult result = run();
+
+  freeChunk(&chunk);
+  return result;
 }
 
 static InterpretResult run() {


### PR DESCRIPTION
Add the beginnings of the compiler, capable of parsing and creating byte code for basic arithmetic. This framework leaves space for adding the more involved parts of the grammar.