### PR TITLE
feat: allow different value types

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -170,7 +170,7 @@ static void binary() {
 
 static void number() {
   double value = strtod(parser.previous.start, NULL);
-  emitConstant(value);
+  emitConstant(NUMBER_VAL(value));
 }
 
 static void grouping() {

--- a/value.c
+++ b/value.c
@@ -27,5 +27,5 @@ void freeValueArray(ValueArray* array) {
 }
 
 void printValue(Value value) {
-  printf("%g", value);
+  printf("%g", AS_NUMBER(value));
 }

--- a/value.h
+++ b/value.h
@@ -3,9 +3,36 @@
 
 #include "common.h"
 
-// abstract how values are handled, so code using them
-// do not need to change when the representation changes
-typedef double Value;
+typedef enum {
+  VAL_BOOL,
+  VAL_NIL,
+  VAL_NUMBER,
+} ValueType;
+
+// a "tagged union" so that fields overlap in memory
+// since it is only one type at a time, noted by the 
+// "type" field
+typedef struct {
+  ValueType type;
+  union {
+    bool boolean;
+    double number;
+  } as;
+} Value;
+
+// handle translating value into a Value object
+#define BOOL_VAL(value)   ((Value){VAL_BOOL, {.boolean = value}})
+#define NIL_VAL           ((Value){VAL_NIL, {.number = 0}})
+#define NUMBER_VAL(value) ((Value){VAL_NUMBER, {.number = value}})
+
+// handle translating Value object into value
+#define AS_BOOL(value)    ((value).as.boolean)
+#define AS_NUMBER(value)  ((value).as.number)
+
+// check the type
+#define IS_BOOL(value)    ((value).type == VAL_BOOL)
+#define IS_NIL(value)     ((value).type == VAL_NIL)
+#define IS_NUMBER(value)  ((value).type == VAL_NUMBER)
 
 // constant pool type
 typedef struct {

--- a/vm.c
+++ b/vm.c
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include <stdio.h>
 
 #include "common.h"
@@ -12,6 +13,7 @@ static InterpretResult run();
 static void resetStack();
 static void push(Value value);
 static Value pop();
+static Value peek(int distance);
 
 void initVM() {
   resetStack();
@@ -25,14 +27,31 @@ void resetStack() {
   vm.stackTop = vm.stack;
 }
 
-void push(Value value) {
+static void runtimeError(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vfprintf(stderr, format, args);
+  va_end(args);
+  fputs("\n", stderr);
+
+  size_t instruction = vm.ip - vm.chunk->code - 1;
+  int line = vm.chunk->lines[instruction];
+  fprintf(stderr, "[line %d] in script\n", line);
+  resetStack();
+}
+
+static void push(Value value) {
   *vm.stackTop = value;
   vm.stackTop++;
 }
 
-Value pop() {
+static Value pop() {
   vm.stackTop--;
   return *vm.stackTop;
+}
+
+static Value peek(int distance) {
+  return vm.stackTop[-1 - distance];
 }
 
 InterpretResult interpret(const char* source) {
@@ -56,11 +75,15 @@ InterpretResult interpret(const char* source) {
 static InterpretResult run() {
 #define READ_BYTE() (*vm.ip++)
 #define READ_CONSTANT() (vm.chunk->constants.values[READ_BYTE()])
-#define BINARY_OP(op) \
+#define BINARY_OP(valueType, op) \
     do { \
-      double b = pop(); \
-      double a = pop(); \
-      push(a op b); \
+      if (!IS_NUMBER(peek(0)) || !IS_NUMBER(peek(1))) { \
+        runtimeError("Operands must be numbers."); \
+        return INTERPRET_RUNTIME_ERROR; \
+      } \
+      double b = AS_NUMBER(pop()); \
+      double a = AS_NUMBER(pop()); \
+      push(valueType(a op b)); \
     } while (false)
 
   for (;;) {
@@ -77,7 +100,7 @@ static InterpretResult run() {
     uint8_t instruction;
     switch (instruction = READ_BYTE()) {
       case OP_ADD: {
-        BINARY_OP(+);
+        BINARY_OP(NUMBER_VAL, +);
         break;
       }
       case OP_CONSTANT: {
@@ -86,15 +109,19 @@ static InterpretResult run() {
         break;
       }
       case OP_DIVIDE: {
-        BINARY_OP(/);
+        BINARY_OP(NUMBER_VAL, /);
         break;
       }
       case OP_MULTIPLY: {
-        BINARY_OP(*);
+        BINARY_OP(NUMBER_VAL, *);
         break;
       }
       case OP_NEGATE: {
-        push(-pop());
+        if (!IS_NUMBER(peek(0))) {
+          runtimeError("Operand must be a number");
+          return INTERPRET_RUNTIME_ERROR;
+        }
+        push(NUMBER_VAL(-AS_NUMBER(pop())));
         break;
       }
       case OP_RETURN: {
@@ -103,7 +130,7 @@ static InterpretResult run() {
         return INTERPRET_OK;
       }
       case OP_SUBTRACT: {
-        BINARY_OP(-);
+        BINARY_OP(NUMBER_VAL, -);
         break;
       }
     }


### PR DESCRIPTION
Where values were forced to be doubles, begin to use a tagged union to allow for different types. No other types are implemented in this MR, but the double-ness is explicitly handled, so that others can be used.