### PR TITLE
feat: add ! operator

### DIFF
--- a/chunk.h
+++ b/chunk.h
@@ -7,6 +7,7 @@
 typedef enum {
   OP_CONSTANT,
   OP_NEGATE,
+  OP_NOT,
   OP_RETURN,
 
   OP_NIL,

--- a/compiler.c
+++ b/compiler.c
@@ -196,6 +196,7 @@ static void unary() {
 
   // emit the operator instruction
   switch (operatorType) {
+    case TOKEN_BANG: emitByte(OP_NOT); break;
     case TOKEN_MINUS: emitByte(OP_NEGATE); break;
     default: return;  // unreachable
   }
@@ -244,7 +245,7 @@ ParseRule rules[] = {
   [TOKEN_SEMICOLON]     = {NULL,     NULL,   PREC_NONE},
   [TOKEN_SLASH]         = {NULL,     binary, PREC_FACTOR},
   [TOKEN_STAR]          = {NULL,     binary, PREC_FACTOR},
-  [TOKEN_BANG]          = {NULL,     NULL,   PREC_NONE},
+  [TOKEN_BANG]          = {unary,    NULL,   PREC_NONE},
   [TOKEN_BANG_EQUAL]    = {NULL,     NULL,   PREC_NONE},
   [TOKEN_EQUAL]         = {NULL,     NULL,   PREC_NONE},
   [TOKEN_EQUAL_EQUAL]   = {NULL,     NULL,   PREC_NONE},

--- a/debug.c
+++ b/debug.c
@@ -47,6 +47,8 @@ int disassembleInstruction(Chunk* chunk, int offset) {
       return simpleInstruction("OP_NEGATE", offset);
     case OP_NIL:
       return simpleInstruction("OP_NIL", offset);
+    case OP_NOT:
+      return simpleInstruction("OP_NOT", offset);
     case OP_RETURN:
       return simpleInstruction("OP_RETURN", offset);
     case OP_SUBTRACT:

--- a/vm.c
+++ b/vm.c
@@ -54,6 +54,11 @@ static Value peek(int distance) {
   return vm.stackTop[-1 - distance];
 }
 
+static bool isFalsey(Value value) {
+  // falsiness/truthiness follows Ruby: nil and false are falsey, all else truthy
+  return IS_NIL(value) || (IS_BOOL(value) && !AS_BOOL(value));
+}
+
 InterpretResult interpret(const char* source) {
   Chunk chunk;
   initChunk(&chunk);
@@ -130,6 +135,10 @@ static InterpretResult run() {
       }
       case OP_NIL: {
         push(NIL_VAL);
+        break;
+      }
+      case OP_NOT: {
+        push(BOOL_VAL(isFalsey(pop())));
         break;
       }
       case OP_RETURN: {


### PR DESCRIPTION
Add the unary operator for negating, through the parser and vm.

```
!false
```
emits
```
0000    1 OP_FALSE
0001    | OP_NOT
0002    2 OP_RETURN

0000    1 OP_FALSE
          [ false ]
0001    | OP_NOT
          [ true ]
0002    2 OP_RETURN
true
```