### PR TITLE
refactor: remove unnecessary forward declarations in vm

### DIFF
--- a/vm.c
+++ b/vm.c
@@ -11,9 +11,6 @@ VM vm;
 static InterpretResult run();
 
 static void resetStack();
-static void push(Value value);
-static Value pop();
-static Value peek(int distance);
 
 void initVM() {
   resetStack();


### PR DESCRIPTION
Nothing particularly bad about forward declarations, but they are unnecessary in this case, so clean them up.